### PR TITLE
Add option to disable sync to media

### DIFF
--- a/jobs/zookeeper/spec
+++ b/jobs/zookeeper/spec
@@ -92,5 +92,5 @@ properties:
     description: "The length of a single tick, which is the basic time unit used by ZooKeeper, as measured in milliseconds"
     default: 2000
   force_sync:
-    description: "Requires updates to be synced to media of the transaction log before finishing processing the update. Setting to 'no' dramatically improves performance at the cost of losing recent commits if all nodes crash at the same time"
+    description: "Requires updates to be synced to media of the transaction log before finishing processing the update. Setting to 'no' improves performance dramatically at the cost of losing recent commits if all nodes crash at the same time"
     default: "yes"

--- a/jobs/zookeeper/spec
+++ b/jobs/zookeeper/spec
@@ -91,3 +91,6 @@ properties:
   tick_time:
     description: "The length of a single tick, which is the basic time unit used by ZooKeeper, as measured in milliseconds"
     default: 2000
+  force_sync:
+    description: "Requires updates to be synced to media of the transaction log before finishing processing the update. Setting to 'no' dramatically improves performance at the cost of losing recent commits if all nodes crash at the same time"
+    default: "yes"

--- a/jobs/zookeeper/templates/zoo.cfg.erb
+++ b/jobs/zookeeper/templates/zoo.cfg.erb
@@ -24,3 +24,4 @@ snapCount=<%= p('snap_count') %>
 syncEnabled=<%= p('sync_enabled') %>
 syncLimit=<%= p('sync_limit') %>
 tickTime=<%= p('tick_time') %>
+forceSync=<%= p('force_sync') %>


### PR DESCRIPTION
Avoiding sync to media for every single update dramatically boosts performance at the cost of losing recent changes if all nodes crash at the same time. When using ext3 or ext4 file system with default settings it is 5 seconds worth of data at most (see man mount -> commit).