### PR TITLE
make zookeeper transaction log dir configurable.

### DIFF
--- a/jobs/zookeeper/spec
+++ b/jobs/zookeeper/spec
@@ -52,6 +52,9 @@ properties:
   cnx_timeout:
     description: "Sets the timeout value for opening connections for leader election notifications"
     default: 5
+  trans_log_dir:
+    description: "The location of transaction log. If not set, transaction log will be stored under /var/vcap/sys/log/zookeeper"
+    default: "/var/vcap/sys/log/zookeeper"
   election_algorim:
     description: "Election implementation to use"
     default: 3

--- a/jobs/zookeeper/templates/zoo.cfg.erb
+++ b/jobs/zookeeper/templates/zoo.cfg.erb
@@ -10,7 +10,7 @@ clientPort=<%= peers.p('client_port') %>
 clientPortAddress=<%= p('listen_address') %>
 cnxTimeout=<%= p('cnx_timeout') %>
 dataDir=/var/vcap/store/zookeeper
-dataLogDir=/var/vcap/sys/log/zookeeper
+dataLogDir=<%= p('trans_log_dir') %>
 electionAlg=<%= p('election_algorim') %>
 fsync.warningthresholdms=<%= p('warning_threshold_ms') %>
 globalOutstandingLimit=<%= p('global_outstanding_limit') %>


### PR DESCRIPTION
Data in /var/vcap/sys/log directory will be lost if VM were failed and recreated. Specifying dataLogDir as /var/vcap/sys/log may cause zookeeper transaction log lost when VM fail.